### PR TITLE
Fix link to [your localization settings] in recurring-invoices.md

### DIFF
--- a/source/docs/recurring-invoices.md
+++ b/source/docs/recurring-invoices.md
@@ -105,6 +105,6 @@ Keep in mind that **[MONTHYEAR|MONTHYEAR]** syntax will take care of **overlappi
 ```
 
 ### Translations
-As you can see [MONTHYEAR|MONTHYEAR] uses "to" between date ranges. This is not hard coded, but it builds itself based on [your localization settings](/docs/settings/#localization).
+As you can see [MONTHYEAR|MONTHYEAR] uses "to" between date ranges. This is not hard coded, but it builds itself based on [your localization settings](/docs/basic-settings/#localization).
 
 <x-next url=/docs/payments>Payments</x-next>


### PR DESCRIPTION
The summary explains it all.

I'm not sure why the GitHub online editor also changed line 110 (I didn't) ... maybe GitHub added a missing end-of-line character in order to make the code POSIX compliant, that is, to change an "incomplete line" (1) to a "complete line" (2).

- (1) https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_195
- (2) https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206