### PR TITLE
Update self-host-updating.md

### DIFF
--- a/source/docs/self-host-updating.md
+++ b/source/docs/self-host-updating.md
@@ -21,6 +21,7 @@ If you have installed Invoice Ninja using just git, then all that is required is
 
 ```bash 
 git pull
+composer install
 php artisan ninja:post-update
 ```
 


### PR DESCRIPTION
update the git self-host upgrade instructions

.. because when the composer.json and composer.lock files are updated, those are not installed if you upgrade from a old 5.x-version.