### PR TITLE
Update hyperlinks to server requirements page

### DIFF
--- a/source/en/self-host-troubleshooting.md
+++ b/source/en/self-host-troubleshooting.md
@@ -10,7 +10,7 @@ locale: en
 
 If you're experiencing issues with your self-hosted Invoice Ninja instance, follow these general troubleshooting steps before diving into the specific sections:
 
-1. Verify that you meet the [minimum system requirements](https://invoiceninja.github.io/en/self-hosting/#requirements).
+1. Verify that you meet the [minimum system requirements](https://invoiceninja.github.io/en/self-host-installation/#server-requirements).
 2. Consult the [Invoice Ninja forum](https://forum.invoiceninja.com/) for community support.
 3. Examine the logs for error messages. You can find the logs in the `storage/logs` directory.
 

--- a/source/fr_CA/self-host-troubleshooting.md
+++ b/source/fr_CA/self-host-troubleshooting.md
@@ -10,7 +10,7 @@ locale: fr_CA
 
 Si vous rencontrez des problèmes avec votre instance Invoice Ninja auto-hébergée, suivez ces étapes générales de dépannage avant de passer aux sections spécifiques :
 
-1. Vérifiez que vous répondez aux [exigences minimales du système](https://invoiceninja.github.io/fr_CA/self-hosting/#requirements).
+1. Vérifiez que vous répondez aux [exigences minimales du système](https://invoiceninja.github.io/fr_CA/self-host-installation/#exigences-du-serveur).
 2. Consultez le [forum Invoice Ninja](https://forum.invoiceninja.com/) pour obtenir une assistance communautaire.
 3. Examinez les journaux pour les messages d'erreur. Vous pouvez trouver les journaux dans le répertoire `storage/logs`.
 


### PR DESCRIPTION
The current system requirements hyperlink found on the [Self Host Troubleshooting](https://invoiceninja.github.io/en/self-host-troubleshooting/) page points to a 404. This PR updates the link to the server requirements listed [here](https://invoiceninja.github.io/en/self-host-installation/#server-requirements).